### PR TITLE
fix: restore crab emojis and fix walking crab JS crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Crabcode
+# Crabcode 🦀
+
+```
+    \___/
+   ( •_•)
+  /)🦀(\
+ <      >
+```
 
 A lightning-fast tmux-based workspace manager for multi-repo development. Start a full dev environment in seconds.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1194,7 +1194,7 @@
           <div class="output">✓ Worktree provisioned: ~/project-workspaces/ws-1</div>
           <div class="output">✓ Branch isolation: workspace-1</div>
           <div class="output">✓ Resource allocation: API=3001, VITE=5174</div>
-          <div class="output">✓ Environment operationalized. <span class="command">Velocity unlocked.</span></div>
+          <div class="output">✓ Environment operationalized. <span class="command">You're in. 🦀</span></div>
         </div>
       </div>
 
@@ -1223,8 +1223,8 @@
         <div class="terminal-preview">
           <div><span class="prompt">$</span> <span class="command">crab slack @engineering-lead "deployment complete, SLAs nominal"</span></div>
           <div class="output">✓ Stakeholder notified (avg response time: 4.2min)</div>
-          <div><span class="prompt">$</span> <span class="command">crab slack #incidents "resolved: P1 latency regression in prod-east"</span></div>
-          <div class="output">✓ Incident communication logged (MTTR improved 23%)</div>
+          <div><span class="prompt">$</span> <span class="command">crab slack #dev "🦀 feature shipped"</span></div>
+          <div class="output">✓ Posted to #dev</div>
         </div>
       </div>
 
@@ -1363,7 +1363,7 @@
     </div>
 
     <div class="command-group">
-      <h3>Environment Lifecycle Management</h3>
+      <h3>🦀 Workspaces</h3>
       <div class="command-grid">
         <div class="command-item">
           <code>crab ws new</code>
@@ -1530,6 +1530,10 @@
 
     typeCommand();
 
+    // Device detection for optimizations
+    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+    const isTouchDevice = window.matchMedia('(hover: none)').matches;
+
     // FLOATING BUBBLES (with cleanup) - fewer on mobile for performance
     function createBubbles() {
       const bubbleCount = isMobile ? 6 : 15; // Reduce bubbles on mobile
@@ -1550,10 +1554,6 @@
       }
     }
     createBubbles();
-
-    // Device detection for other optimizations
-    const isMobile = window.matchMedia('(max-width: 768px)').matches;
-    const isTouchDevice = window.matchMedia('(hover: none)').matches;
 
     // WALKING CRAB - works on all devices
     if (!document.querySelector('.walking-crab')) {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,4 +1,11 @@
-# Crabcode
+# Crabcode 🦀
+
+```
+    \___/
+   ( •_•)
+  /)🦀(\
+ <      >
+```
 
 > Lightning-fast tmux workspace manager for multi-repo development
 


### PR DESCRIPTION
## Summary
- Restore 3 crab emojis removed during the enterprise redesign (`7187717`)
- Fix JS `ReferenceError` crash that prevented the walking crab from rendering (`f75b96b`)
- Add crab ASCII mascot to `README.md` and `docs/llms.txt` (from unmerged `ebf7348`)

## Bug Fix
The mobile styles commit moved `const isMobile` **after** `createBubbles()` which references it. Since `const` has a temporal dead zone, the script crashed on load — killing the walking crab, parallax crabs, and cursor trail.

**Before:** `createBubbles()` → uses `isMobile` → 💥 `ReferenceError` → script dies → no walking crab
**After:** `isMobile`/`isTouchDevice` declared before any usage → everything works

## Restored Emojis
| Location | Before | After |
|----------|--------|-------|
| Terminal preview | `Velocity unlocked.` | `You're in. 🦀` |
| Slack example | Corporate incident speak | `crab slack #dev "🦀 feature shipped"` |
| Command header | `Environment Lifecycle Management` | `🦀 Workspaces` |

## Test plan
- [ ] Open `docs/index.html` in browser — walking crab should appear at bottom
- [ ] Click walking crab — crab rain should trigger
- [ ] Enter Konami code (↑↑↓↓←→←→BA) — crab rain should trigger
- [ ] Verify floating bubbles appear
- [ ] Check mobile viewport — fewer bubbles, no parallax crabs
- [ ] Confirm 3 restored crab emojis visible on page
- [ ] Verify no JS console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)