### PR TITLE
feat: add user-configurable command alias system

### DIFF
--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -1,5 +1,11 @@
 # Example: Minimal Configuration
 # Bare minimum config to get started
+#
+# Tip: Add command aliases in ~/.crabcode/config.yaml:
+#   aliases:
+#     cu: cleanup
+#     r: restart
+#     wn: ws new
 
 session_name: dev
 workspace_base: ~/Dev/my-project/workspaces

--- a/src/crabcode
+++ b/src/crabcode
@@ -309,7 +309,7 @@ resolve_command_aliases() {
   fi
 
   local resolved
-  resolved=$(yq -r ".aliases.\"$cmd\" // \"\"" "$GLOBAL_CONFIG" 2>/dev/null)
+  resolved=$(cmd="$cmd" yq -r '.aliases.[strenv(cmd)] // ""' "$GLOBAL_CONFIG" 2>/dev/null)
   if [ -n "$resolved" ] && [ "$resolved" != "null" ]; then
     echo "$resolved"
     return 0
@@ -8047,7 +8047,7 @@ handle_alias_command() {
       fi
 
       local aliases
-      aliases=$(yq -r '.aliases // {} | to_entries[] | .key + " → " + .value' "$GLOBAL_CONFIG" 2>/dev/null)
+      aliases=$(yq -r '.aliases // {} | to_entries[] | .key + " → " + (.value | tostring)' "$GLOBAL_CONFIG" 2>/dev/null)
       if [ -z "$aliases" ]; then
         echo -e "${YELLOW}No aliases configured.${NC}"
         echo ""
@@ -8071,6 +8071,12 @@ handle_alias_command() {
         error "Usage: crab alias set <name> <command...>"
         exit 1
       fi
+      # Validate alias name
+      if ! [[ "$name" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        error "Invalid alias name '$name'. Use only letters, numbers, hyphens, and underscores."
+        exit 1
+      fi
+
       shift 2
       local value="$*"
       if [ -z "$value" ]; then
@@ -8084,7 +8090,7 @@ handle_alias_command() {
         echo "{}" > "$GLOBAL_CONFIG"
       fi
 
-      yq -i ".aliases.\"$name\" = \"$value\"" "$GLOBAL_CONFIG"
+      NAME="$name" VALUE="$value" yq -i '.aliases.[strenv(NAME)] = strenv(VALUE)' "$GLOBAL_CONFIG"
       echo -e "${GREEN}Alias set:${NC} $name → $value"
       ;;
     "rm"|"remove"|"delete")
@@ -8100,13 +8106,13 @@ handle_alias_command() {
       fi
 
       local existing
-      existing=$(yq -r ".aliases.\"$name\" // \"\"" "$GLOBAL_CONFIG" 2>/dev/null)
+      existing=$(NAME="$name" yq -r '.aliases.[strenv(NAME)] // ""' "$GLOBAL_CONFIG" 2>/dev/null)
       if [ -z "$existing" ] || [ "$existing" = "null" ]; then
         error "Alias '$name' not found"
         exit 1
       fi
 
-      yq -i "del(.aliases.\"$name\")" "$GLOBAL_CONFIG"
+      NAME="$name" yq -i 'del(.aliases.[strenv(NAME)])' "$GLOBAL_CONFIG"
 
       # Clean up empty aliases map
       local remaining
@@ -8144,9 +8150,9 @@ main() {
   # Resolve user-configured command aliases (before project + command dispatch)
   if resolved=$(resolve_command_aliases "${1:-}"); then
     shift
-    # Split resolved alias into words and prepend to remaining args
-    # shellcheck disable=SC2086
-    set -- $resolved "$@"
+    # Split resolved alias into words without glob expansion
+    read -r -a resolved_parts <<<"$resolved"
+    set -- "${resolved_parts[@]}" "$@"
   fi
 
   # For project-aware commands, resolve project (cwd-first, then default)

--- a/src/crabcode
+++ b/src/crabcode
@@ -298,6 +298,25 @@ resolve_project_from_cwd() {
   return 1
 }
 
+# Resolve user-configured command aliases from global config
+# Expands alias to one or more words, prepending to remaining args
+resolve_command_aliases() {
+  local cmd="${1:-}"
+  [ -z "$cmd" ] && return 1
+
+  if [ ! -f "$GLOBAL_CONFIG" ]; then
+    return 1
+  fi
+
+  local resolved
+  resolved=$(yq -r ".aliases.\"$cmd\" // \"\"" "$GLOBAL_CONFIG" 2>/dev/null)
+  if [ -n "$resolved" ] && [ "$resolved" != "null" ]; then
+    echo "$resolved"
+    return 0
+  fi
+  return 1
+}
+
 # Check if we're in legacy single-project mode
 is_legacy_config() {
   # Legacy = config.yaml has main_repo AND projects/ dir is empty/missing
@@ -6318,6 +6337,17 @@ show_cheat() {
 ║                                                                               ║
 ╠═══════════════════════════════════════════════════════════════════════════════╣
 ║                                                                               ║
+║  COMMAND ALIASES (crab alias ...)                                            ║
+║  ────────────────────────────────────────────────────────────────────────     ║
+║  crab alias              List all aliases                                     ║
+║  crab alias set cu cleanup          Set alias: cu → cleanup                  ║
+║  crab alias set wn "ws new"         Multi-word: wn → ws new                  ║
+║  crab alias rm cu        Remove an alias                                      ║
+║                                                                               ║
+║  Config: ~/.crabcode/config.yaml (aliases section)                           ║
+║                                                                               ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
 ║  MOBILE COMPANION (crab mobile ...)                                           ║
 ║  ────────────────────────────────────────────────────────────────────────     ║
 ║  crab mobile setup     Setup push notifications (ntfy.sh)                     ║
@@ -6427,6 +6457,11 @@ show_help() {
   echo "  projects          List registered projects"
   echo "  default [alias]   Show/set default project"
   echo "  init              Register a new project (asks for alias)"
+  echo ""
+  echo "Alias Commands:"
+  echo "  alias             List all aliases"
+  echo "  alias set <name> <cmd>  Set a command alias"
+  echo "  alias rm <name>   Remove an alias"
   echo ""
   echo "Other Commands:"
   echo "  init              Setup config (auto-detects project type)"
@@ -7995,6 +8030,106 @@ handle_court_command() {
 }
 
 # =============================================================================
+# Alias Management
+# =============================================================================
+
+handle_alias_command() {
+  local subcmd="${1:-}"
+
+  case "$subcmd" in
+    "")
+      # List all aliases
+      if [ ! -f "$GLOBAL_CONFIG" ]; then
+        echo -e "${YELLOW}No aliases configured.${NC}"
+        echo ""
+        echo "Set one with: crab alias set <name> <command...>"
+        return
+      fi
+
+      local aliases
+      aliases=$(yq -r '.aliases // {} | to_entries[] | .key + " → " + .value' "$GLOBAL_CONFIG" 2>/dev/null)
+      if [ -z "$aliases" ]; then
+        echo -e "${YELLOW}No aliases configured.${NC}"
+        echo ""
+        echo "Set one with: crab alias set <name> <command...>"
+        return
+      fi
+
+      echo -e "${CYAN}Command Aliases${NC}"
+      echo ""
+      while IFS= read -r line; do
+        local name="${line%% →*}"
+        local value="${line#*→ }"
+        echo -e "  ${GREEN}$name${NC} → $value"
+      done <<< "$aliases"
+      echo ""
+      echo -e "${GRAY}Config: $GLOBAL_CONFIG${NC}"
+      ;;
+    "set"|"add")
+      local name="${2:-}"
+      if [ -z "$name" ]; then
+        error "Usage: crab alias set <name> <command...>"
+        exit 1
+      fi
+      shift 2
+      local value="$*"
+      if [ -z "$value" ]; then
+        error "Usage: crab alias set <name> <command...>"
+        exit 1
+      fi
+
+      # Ensure global config exists
+      mkdir -p "$CONFIG_DIR"
+      if [ ! -f "$GLOBAL_CONFIG" ]; then
+        echo "{}" > "$GLOBAL_CONFIG"
+      fi
+
+      yq -i ".aliases.\"$name\" = \"$value\"" "$GLOBAL_CONFIG"
+      echo -e "${GREEN}Alias set:${NC} $name → $value"
+      ;;
+    "rm"|"remove"|"delete")
+      local name="${2:-}"
+      if [ -z "$name" ]; then
+        error "Usage: crab alias rm <name>"
+        exit 1
+      fi
+
+      if [ ! -f "$GLOBAL_CONFIG" ]; then
+        error "No aliases configured"
+        exit 1
+      fi
+
+      local existing
+      existing=$(yq -r ".aliases.\"$name\" // \"\"" "$GLOBAL_CONFIG" 2>/dev/null)
+      if [ -z "$existing" ] || [ "$existing" = "null" ]; then
+        error "Alias '$name' not found"
+        exit 1
+      fi
+
+      yq -i "del(.aliases.\"$name\")" "$GLOBAL_CONFIG"
+
+      # Clean up empty aliases map
+      local remaining
+      remaining=$(yq -r '.aliases // {} | length' "$GLOBAL_CONFIG" 2>/dev/null)
+      if [ "$remaining" = "0" ]; then
+        yq -i 'del(.aliases)' "$GLOBAL_CONFIG"
+      fi
+
+      echo -e "${GREEN}Removed alias:${NC} $name"
+      ;;
+    *)
+      error "Unknown alias subcommand: $subcmd"
+      echo ""
+      echo "Usage:"
+      echo "  crab alias              List all aliases"
+      echo "  crab alias set <name> <command...>  Set an alias"
+      echo "  crab alias rm <name>    Remove an alias"
+      exit 1
+      ;;
+  esac
+}
+
+# =============================================================================
 # Main Entry Point
 # =============================================================================
 
@@ -8004,6 +8139,14 @@ main() {
   if [[ "${1:-}" == @* ]]; then
     resolve_project "$1"
     shift
+  fi
+
+  # Resolve user-configured command aliases (before project + command dispatch)
+  if resolved=$(resolve_command_aliases "${1:-}"); then
+    shift
+    # Split resolved alias into words and prepend to remaining args
+    # shellcheck disable=SC2086
+    set -- $resolved "$@"
   fi
 
   # For project-aware commands, resolve project (cwd-first, then default)
@@ -8084,6 +8227,9 @@ main() {
       ;;
     "default")
       set_default_project "${2:-}"
+      ;;
+    "alias"|"aliases")
+      handle_alias_command "${@:2}"
       ;;
     "new"|"create")
       # Shorthand: crab new -> crab ws new

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -424,6 +424,57 @@ rm -rf test-share-dir
 echo ""
 
 # =============================================================================
+# Test 12: Command Aliases
+# =============================================================================
+
+log "Testing command aliases..."
+
+# List aliases (should be empty initially)
+run_test "crab alias (empty)" \
+  "crab alias" \
+  "No aliases configured"
+
+# Set a single-word alias
+run_test "crab alias set (single word)" \
+  "crab alias set cu cleanup" \
+  "Alias set.*cu.*cleanup"
+
+# List aliases (should show the alias)
+run_test "crab alias (lists alias)" \
+  "crab alias" \
+  "cu.*cleanup"
+
+# Set a multi-word alias
+run_test "crab alias set (multi-word)" \
+  "crab alias set wn 'ws new'" \
+  "Alias set.*wn.*ws new"
+
+# List aliases (should show both)
+run_test "crab alias (lists multiple)" \
+  "crab alias" \
+  "cu.*cleanup"
+
+# Remove an alias
+run_test "crab alias rm" \
+  "crab alias rm cu" \
+  "Removed alias.*cu"
+
+# Verify removed alias is gone
+run_test "crab alias rm (alias removed)" \
+  "crab alias rm cu 2>&1" \
+  "not found"
+
+# Invalid alias name rejected
+run_test "crab alias set (invalid name rejected)" \
+  "crab alias set 'bad name!' cleanup 2>&1" \
+  "Invalid alias name"
+
+# Clean up remaining test alias
+crab alias rm wn 2>/dev/null || true
+
+echo ""
+
+# =============================================================================
 # Summary
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds a user-configurable command alias system stored in `~/.crabcode/config.yaml` under an `aliases:` key
- Aliases expand before dispatch, supporting multi-word expansion (e.g. `wn` → `ws new`)
- New `crab alias` subcommand for managing aliases: `set`, `rm`, and list

## Usage

```bash
crab alias set cu cleanup        # single command
crab alias set wn "ws new"       # multi-word expansion
crab alias                       # list aliases
crab alias rm cu                 # remove
crab cu                          # runs cleanup
```

Config format in `~/.crabcode/config.yaml`:
```yaml
aliases:
  cu: cleanup
  r: restart
  wn: ws new
```

## Test plan

- [x] `crab alias` shows empty state with usage hint
- [x] `crab alias set cu cleanup` writes to global config
- [x] `crab alias` lists the alias
- [x] `crab cu` from a workspace dir runs cleanup
- [x] `crab alias set wn "ws new"` sets multi-word alias
- [x] `crab wn` expands to `crab ws new`
- [x] `crab alias rm cu` removes the alias
- [x] `crab cu` after removal shows "Unknown command"
- [x] `crab help` and `crab cheat` show alias documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)