### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/src/crabcode
+++ b/src/crabcode
@@ -27,7 +27,7 @@
 
 set -e
 
-VERSION="0.9.0"
+VERSION="0.9.1"
 CONFIG_DIR="$HOME/.crabcode"
 CONFIG_FILE="$CONFIG_DIR/config.yaml"
 WIP_BASE="$CONFIG_DIR/wip"


### PR DESCRIPTION
## Summary
- Patch version bump `0.9.0` → `0.9.1` to release text-to-speech for received messages (#20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)