### PR TITLE
fix(msg): stop say from repeating in listen mode

### DIFF
--- a/src/crabcode
+++ b/src/crabcode
@@ -5879,11 +5879,12 @@ msg_listen() {
         msg_log "<" "$from" "$text"
         msg_say "$from" "$text"
       done
-      # Update last_ts to the latest message timestamp
+      # Update last_ts to the latest message timestamp (keep full float precision
+      # so the relay's strict > comparison excludes already-seen messages)
       local new_ts
       new_ts=$(echo "$response" | jq -r '.[-1].ts // 0' 2>/dev/null)
       if [ -n "$new_ts" ] && [ "$new_ts" != "0" ]; then
-        last_ts="${new_ts%.*}"
+        last_ts="$new_ts"
       fi
     fi
 


### PR DESCRIPTION
## Summary
- `msg_listen` was truncating message timestamps from float to integer (`${new_ts%.*}`), e.g. `1707849600.5` → `1707849600`
- The relay uses strict `>` comparison, so the truncated integer timestamp caused already-seen messages to be re-fetched every 2-second poll cycle
- This triggered `msg_say` (TTS) repeatedly for the same message, never "clearing" it
- Fix: preserve the full float timestamp so the relay correctly excludes already-seen messages

## Test plan
- [ ] Run `crab msg listen` and send a message — verify it displays once and TTS fires once
- [ ] Verify subsequent polls don't re-display or re-speak the same message
- [ ] Send multiple messages in quick succession — all should display exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)