### PR TITLE
fix(crab-pf): replace broken verify with smoke+session test, add session handling

### DIFF
--- a/plugins/promptfoo/src/agent/providers.ts
+++ b/plugins/promptfoo/src/agent/providers.ts
@@ -63,8 +63,12 @@ export class OpenAIProvider implements LLMProvider {
         model: this.model,
         messages: options.messages.map((m) => this.toOpenAIMessage(m)),
         tools: options.tools,
-        max_tokens: options.maxTokens || 4096,
-        temperature: options.temperature ?? 0.7,
+        ...(this.model.startsWith('gpt-5') || this.model.startsWith('o1') || this.model.startsWith('o3')
+          ? { max_completion_tokens: options.maxTokens || 4096 }
+          : { max_tokens: options.maxTokens || 4096 }),
+        ...(this.model.startsWith('gpt-5') || this.model.startsWith('o1') || this.model.startsWith('o3')
+          ? {}
+          : { temperature: options.temperature ?? 0.7 }),
       }),
     });
 

--- a/plugins/promptfoo/src/agent/tools.ts
+++ b/plugins/promptfoo/src/agent/tools.ts
@@ -133,7 +133,7 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'verify',
-    description: 'Run a mini redteam test to verify the configuration works. This sends a few test prompts through the target.',
+    description: 'Verify the configuration works. Tests the provider directly (smoke + session test), then runs promptfoo eval with 2 simple test cases.',
     parameters: {
       type: 'object',
       properties: {
@@ -141,11 +141,6 @@ export const toolDefinitions: ToolDefinition[] = [
           type: 'string',
           description: 'Path to the config file to verify (default: promptfooconfig.yaml)',
           default: 'promptfooconfig.yaml',
-        },
-        numTests: {
-          type: 'number',
-          description: 'Number of test prompts to send (default: 3)',
-          default: 3,
         },
       },
     },

--- a/plugins/promptfoo/src/generator/config.ts
+++ b/plugins/promptfoo/src/generator/config.ts
@@ -62,26 +62,16 @@ export function generateConfig(options: GenerateConfigOptions): GeneratedConfig 
   const config = {
     description,
     providers: [provider],
-    // Default test with the prompt variable
+    prompts: ['{{prompt}}'],
     defaultTest: {
-      vars: {
-        prompt: '{{prompt}}',
-      },
-    },
-    // Mini redteam for verification
-    redteam: {
-      plugins: ['harmful:hate'],
-      strategies: [
-        { id: 'jailbreak' },
-        {
-          id: 'jailbreak:composite',
-          config: {
-            maxTurns: 3,
-          },
-        },
+      assert: [
+        { type: 'javascript', value: 'output && output.length > 0' },
       ],
-      numTests: 1,
     },
+    tests: [
+      { vars: { prompt: 'Hello, how are you?' } },
+      { vars: { prompt: 'What can you help me with?' } },
+    ],
   };
 
   // Generate YAML


### PR DESCRIPTION
## Summary

- **Fix false-positive verification**: The old verify tool ran `promptfoo eval` against a config with `redteam` section but no `tests` array — zero tests ran, zero failures, reported success. Now replaced with a 3-step process: direct provider smoke test → session test → eval with 2 real test cases.
- **Add session handling context**: System prompt now teaches the agent about the `callApi(prompt, context, options)` signature and `sessionId` contract needed for multi-turn redteam attacks (Crescendo, GOAT).
- **Fix GPT-5/o1/o3 compatibility**: Use `max_completion_tokens` instead of `max_tokens`, omit `temperature` for reasoning models.
- **Fix Node.js module caching**: `await import(url)` returns cached module when provider.js is rewritten. Added `?t=timestamp` cache buster.

## Changed files

| File | What changed |
|------|-------------|
| `generator/config.ts` | Replace `redteam` section with `prompts` + `tests` + `defaultTest.assert` |
| `agent/loop.ts` | Rewrite `verify` tool: smoke test + session test + eval with proper parsing |
| `agent/tools.ts` | Update verify description, remove unused `numTests` param |
| `agent/system-prompt.ts` | Add session handling section, update `callApi` signature in example |
| `agent/providers.ts` | GPT-5/o1/o3 compat (`max_completion_tokens`, no `temperature`) |

## Test plan

- [ ] Run `crab pf` against a simple HTTP target — verify eval shows `2 passed, 0 failed`
- [ ] Run against a session-based target — verify provider gets correct `callApi` signature and returns `sessionId`
- [ ] Run with `--provider openai:gpt-5` — verify no API errors
- [ ] Break provider.js intentionally — verify smoke test catches it (not false-positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)