### PR TITLE
fix(crab-pf): require test prompts to match provider input format

### DIFF
--- a/plugins/promptfoo/src/agent/system-prompt.ts
+++ b/plugins/promptfoo/src/agent/system-prompt.ts
@@ -98,6 +98,8 @@ For **HTTP providers**: Use \`sessionParser\` in the config to extract the sessi
 5. Verify — runs provider smoke test + session test, then promptfoo eval with 2 test cases
 6. Call done() with results
 
+**Test prompts in promptfooconfig.yaml MUST match the input format your provider expects.** If the provider parses JSON objects, test with valid JSON. If it expects keywords, test with those keywords. Generic prompts like "Hello" will fail providers that require structured input.
+
 Be intelligent. Figure out the target's protocol, auth, request/response format from probing. Generate configs that work.`;
 
 export function getDiscoveryPrompt(additionalContext?: string): string {


### PR DESCRIPTION
## Summary
- Add system prompt rule requiring test prompts in promptfooconfig.yaml to match the provider's expected input format
- Fixes false-positive verifications where providers expecting structured input (JSON objects, keywords) pass smoke tests but fail eval with generic prompts like "Hello"

## Test plan
- [ ] Run `crab pf` against app 09 (expects JSON-structured prompts) — verify generated test cases are valid JSON
- [ ] Run `crab pf` against app 11 (expects keyword prompts) — verify generated test cases use keywords like "summary"/"transactions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)