### PR TITLE
feat(crab-pf): default to gpt-5 with reasoning low

### DIFF
--- a/plugins/promptfoo/src/agent/providers.ts
+++ b/plugins/promptfoo/src/agent/providers.ts
@@ -266,7 +266,7 @@ export function createProvider(provider: string, options?: { reasoningEffort?: s
 
   switch (type) {
     case 'openai':
-      return new OpenAIProvider({ model: model || 'gpt-4o', reasoningEffort: options?.reasoningEffort });
+      return new OpenAIProvider({ model: model || 'gpt-5', reasoningEffort: options?.reasoningEffort });
     case 'anthropic':
       return new AnthropicProvider({ model: model || 'claude-sonnet-4-20250514' });
     default:

--- a/plugins/promptfoo/src/cli.ts
+++ b/plugins/promptfoo/src/cli.ts
@@ -23,11 +23,11 @@ async function main() {
     // Parse arguments
     const filePath = getArg('--file') || getArg('-f');
     const urlArg = getArg('--url');
-    const providerStr = getArg('--provider') || process.env.DISCOVERY_PROVIDER || 'openai:gpt-4o';
+    const providerStr = getArg('--provider') || process.env.DISCOVERY_PROVIDER || 'openai:gpt-5';
     const outputDir = getArg('--output') || getArg('-o') || '.';
     const verbose = args.includes('--verbose') || args.includes('-v');
     const maxTurns = parseInt(getArg('--max-turns') || '30', 10);
-    const reasoningEffort = getArg('--reasoning');
+    const reasoningEffort = getArg('--reasoning') || 'low';
 
     let context: string;
 
@@ -133,7 +133,7 @@ Options:
   --file, -f <path>      Read target specification from file
   --url <url>            Probe a URL directly
   --output, -o <dir>     Output directory (default: current dir)
-  --provider <provider>  LLM provider (default: openai:gpt-4o)
+  --provider <provider>  LLM provider (default: openai:gpt-5)
   --max-turns <n>        Max agent turns (default: 30)
   --reasoning <effort>   Reasoning effort for GPT-5/o-series (low, medium, high)
   --verbose, -v          Show detailed output


### PR DESCRIPTION
## Summary
- Changes default provider from `openai:gpt-4o` to `openai:gpt-5`
- Changes default reasoning effort from none to `low`
- Based on 11/11 test results showing GPT-5 low outperforms GPT-4o across all target apps

## Test plan
- [x] Tested all 11 target apps with GPT-5 + reasoning low (11/11 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)