### PR TITLE
feat(env): add crab env encrypt command

### DIFF
--- a/src/crabcode
+++ b/src/crabcode
@@ -11205,11 +11205,15 @@ handle_env_command() {
     "restore")
       env_restore "$@"
       ;;
+    "encrypt")
+      env_encrypt "$@"
+      ;;
     ""|"help"|"-h"|"--help")
       echo -e "${BOLD}crab env${NC} - Environment snapshot & restore"
       echo ""
       echo -e "  ${CYAN}crab env snapshot${NC}              Capture environment recipe"
       echo -e "  ${CYAN}crab env snapshot --dry-run${NC}    Preview what would be captured"
+      echo -e "  ${CYAN}crab env encrypt <staging-dir>${NC} Encrypt a staging directory"
       echo -e "  ${CYAN}crab env restore --from FILE${NC}   Restore from snapshot"
       echo ""
       echo "Snapshot launches an AI agent to explore your machine and build"
@@ -11391,7 +11395,24 @@ PROMPT_EOF
     ${EDITOR:-vim} "$staging_dir/recipe.md"
   fi
 
-  # Package and encrypt
+  env_encrypt "$staging_dir" "$output_path"
+}
+
+# Encrypt a staging directory into a portable .enc bundle
+env_encrypt() {
+  local staging_dir="$1"
+  local output_path="${2:-}"
+
+  if [ -z "$staging_dir" ] || [ ! -d "$staging_dir" ]; then
+    error "Staging directory not found: ${staging_dir:-<none>}"
+    return 1
+  fi
+
+  if [ ! -f "$staging_dir/recipe.md" ]; then
+    error "No recipe.md found in $staging_dir — is this a valid snapshot?"
+    return 1
+  fi
+
   echo ""
   echo -e "${CYAN}Encrypting snapshot...${NC}"
   echo -e "${GRAY}Choose a password to protect this snapshot.${NC}"
@@ -11400,6 +11421,7 @@ PROMPT_EOF
 
   # Determine output path
   if [ -z "$output_path" ]; then
+    local timestamp=$(date +%Y%m%d-%H%M%S)
     output_path="$ENV_SNAPSHOT_DIR/env-snapshot-$timestamp.enc"
   fi
   mkdir -p "$(dirname "$output_path")"


### PR DESCRIPTION
## Summary
- Extract encryption logic from `env_snapshot` into a standalone `env_encrypt` function
- Add `crab env encrypt <staging-dir>` command so users can retry encryption if the password verification fails, without re-running the full snapshot agent
- Add validation (checks staging dir exists and contains recipe.md)

## Test plan
- [ ] Run `crab env snapshot`, intentionally fail password verify, then retry with `crab env encrypt <staging-dir>`
- [ ] Run `crab env encrypt` with invalid path — should error
- [ ] Run `crab env encrypt` on dir without recipe.md — should error
- [ ] Verify `crab env help` shows the new command

🤖 Generated with [Claude Code](https://claude.com/claude-code)