### PR TITLE
refactor(ci): add shared ci success

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,20 @@ jobs:
 
       - name: Run shellcheck
         run: shellcheck --severity=error src/crabcode
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [unit, lint]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      statuses: read
+
+    steps:
+      - name: Wait for all PR checks to succeed
+        uses: promptfoo/.github/.github/actions/ci-success@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          timeout-seconds: 300


### PR DESCRIPTION
Add a CI Success job to the existing test workflow, use the shared first-party action from promptfoo/.github, and keep the current unit and shellcheck jobs intact. Test plan: verify the updated workflow parses and CI Success waits for the existing PR checks.