### PR TITLE
[codex] fix ci success on main pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     needs: [unit, lint]
-    if: always()
+    # The shared action waits for all PR checks on this commit; on push to main
+    # it can also pick up unrelated branch checks (for example Dependabot).
+    if: ${{ always() && github.event_name == 'pull_request' }}
     timeout-minutes: 5
     permissions:
       checks: read


### PR DESCRIPTION
## Summary

`test` workflow runs on direct pushes to `main` are failing in the aggregate `CI Success` job even when this repo's `Unit tests (bats)` and `Shellcheck` jobs pass.

## Root cause

`CI Success` uses the shared `promptfoo/.github` action that waits for all checks on the commit. That is the right behavior for pull requests, but on `push` events to `main` the same commit can also have unrelated branch-level checks such as `Dependabot` and CodeQL checks. In the failing run for `9b1c42b`, `Dependabot` completed with `failure`, so `CI Success` failed this workflow despite the repo-local jobs passing.

## Fix

Keep `CI Success` for `pull_request` events, but skip it on `push` events. The repo-local `unit` and `lint` jobs still run on pushes to `main`, and the workflow result now reflects those jobs instead of unrelated checks.

## Validation

- `make test-unit`
- `shellcheck --severity=error src/crabcode`
