### PR TITLE
fix: code scanning alert 4 in Burp XML parsing

### DIFF
--- a/plugins/promptfoo/src/parsers/burp-entities.test.ts
+++ b/plugins/promptfoo/src/parsers/burp-entities.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBurpSingle } from './burp.js';
+
+describe('parseBurpSingle XML entity decoding', () => {
+  it('decodes ampersands after other entities', () => {
+    const parsed = parseBurpSingle(`
+      <items>
+        <item>
+          <url>https://example.com/search?note=&amp;quot;</url>
+          <host>example.com</host>
+          <port>443</port>
+          <protocol>https</protocol>
+          <method>GET</method>
+          <path>/search?note=&amp;quot;</path>
+          <request></request>
+        </item>
+      </items>
+    `);
+
+    expect(parsed.raw).toContain('note=&quot;');
+  });
+});

--- a/plugins/promptfoo/src/parsers/burp.ts
+++ b/plugins/promptfoo/src/parsers/burp.ts
@@ -122,9 +122,9 @@ function decodeXmlEntities(str: string): string {
   return str
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'");
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
 }
 
 /**


### PR DESCRIPTION
## Summary
- decode ampersands after the other XML entities in the Burp parser
- add a regression test for double-unescape input

## Root Cause
The Burp XML parser decoded &amp; before the other named entities. That let encoded entity sequences such as &amp;quot; get decoded twice.

## Validation
- npm test -- src/parsers/burp-entities.test.ts
- npm run build
