### PR TITLE
fix: code scanning alert 6 in Burp item extraction

### DIFF
--- a/plugins/promptfoo/src/parsers/burp-items.test.ts
+++ b/plugins/promptfoo/src/parsers/burp-items.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBurp } from './burp.js';
+
+describe('parseBurp item extraction', () => {
+  it('parses multiple Burp items without regex backtracking', () => {
+    const repeatedNoise = '<item>a'.repeat(2000);
+    const xml = `
+      <items>
+        <metadata>${repeatedNoise}</metadata>
+        <item>
+          <url>https://example.com/one</url>
+          <host>example.com</host>
+          <port>443</port>
+          <protocol>https</protocol>
+          <method>GET</method>
+          <path>/one</path>
+          <request></request>
+        </item>
+        <item>
+          <url>https://example.com/two</url>
+          <host>example.com</host>
+          <port>443</port>
+          <protocol>https</protocol>
+          <method>POST</method>
+          <path>/two</path>
+          <request></request>
+        </item>
+      </items>
+    `;
+
+    const parsed = parseBurp(xml);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed.map((item) => item.url)).toEqual([
+      'https://example.com/one',
+      'https://example.com/two',
+    ]);
+  });
+});

--- a/plugins/promptfoo/src/parsers/burp.ts
+++ b/plugins/promptfoo/src/parsers/burp.ts
@@ -42,11 +42,7 @@ export function parseBurpSingle(xml: string): ParsedArtifact {
 function extractItems(xml: string): BurpItem[] {
   const items: BurpItem[] = [];
 
-  // Match <item> elements
-  const itemMatches = xml.matchAll(/<item>([\s\S]*?)<\/item>/gi);
-
-  for (const match of itemMatches) {
-    const itemXml = match[1];
+  for (const itemXml of extractElementContents(xml, 'item')) {
 
     const url = extractTag(itemXml, 'url');
     const host = extractTag(itemXml, 'host');
@@ -67,6 +63,31 @@ function extractItems(xml: string): BurpItem[] {
         request,
       });
     }
+  }
+
+  return items;
+}
+
+function extractElementContents(xml: string, tag: string): string[] {
+  const items: string[] = [];
+  const openTag = `<${tag}>`;
+  const closeTag = `</${tag}>`;
+  let startIndex = 0;
+
+  while (startIndex < xml.length) {
+    const openIndex = xml.indexOf(openTag, startIndex);
+    if (openIndex === -1) {
+      break;
+    }
+
+    const contentStart = openIndex + openTag.length;
+    const closeIndex = xml.indexOf(closeTag, contentStart);
+    if (closeIndex === -1) {
+      break;
+    }
+
+    items.push(xml.slice(contentStart, closeIndex));
+    startIndex = closeIndex + closeTag.length;
   }
 
   return items;


### PR DESCRIPTION
## Summary
- replace the whole-document item regex with an index-based item scanner
- add a regression test with repeated item-like noise plus multiple real items

## Root Cause
CodeQL flagged the Burp item extraction regex as polynomial-time on crafted XML input because it scanned the entire export with a backtracking pattern.

## Validation
- npm test -- src/parsers/burp-items.test.ts
- npm run build
