### PR TITLE
fix: code scanning alert 10 in provider dependency install

### DIFF
--- a/plugins/promptfoo/src/agent/loop-install.test.ts
+++ b/plugins/promptfoo/src/agent/loop-install.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileSyncMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync: execFileSyncMock,
+  execSync: vi.fn(),
+}));
+
+describe('installProviderDependencies', () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it('invokes npm without building a shell string', async () => {
+    const { installProviderDependencies } = await import('./loop.js');
+
+    installProviderDependencies('/tmp/provider with spaces');
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'npm',
+      ['install', '--silent'],
+      expect.objectContaining({
+        cwd: '/tmp/provider with spaces',
+        timeout: 60000,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    );
+  });
+});

--- a/plugins/promptfoo/src/agent/loop.ts
+++ b/plugins/promptfoo/src/agent/loop.ts
@@ -14,7 +14,7 @@ import type { LLMProvider, Message, ToolCall, ChatResponse } from './providers.j
 import type { DiscoveryResult } from '../types.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 export interface AgentOptions {
@@ -193,6 +193,15 @@ Steps:
   };
 }
 
+export function installProviderDependencies(outputDir: string): void {
+  execFileSync('npm', ['install', '--silent'], {
+    cwd: outputDir,
+    timeout: 60000,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
 /**
  * Execute a single tool call
  */
@@ -287,10 +296,7 @@ async function executeTool(
           const packageJsonPath = path.join(outputDir, 'package.json');
           if (fs.existsSync(packageJsonPath)) {
             try {
-              execSync(`cd "${outputDir}" && npm install --silent 2>&1`, {
-                timeout: 60000,
-                encoding: 'utf-8',
-              });
+              installProviderDependencies(outputDir);
             } catch {
               // Ignore install errors, will surface in import
             }


### PR DESCRIPTION
## Summary
- move provider dependency installation to execFileSync with explicit argv
- keep the existing cwd, timeout, and error swallowing behavior
- add a unit test that verifies npm is invoked without a shell string

## Root Cause
The verify path built a shell command with the output directory embedded in it before running npm install.

## Validation
- npm test -- src/agent/loop-install.test.ts
- npm run build
