### PR TITLE
[codex] Fix code scanning alert 2 in generated config path flow

### DIFF
--- a/plugins/promptfoo/src/agent/loop.ts
+++ b/plugins/promptfoo/src/agent/loop.ts
@@ -41,6 +41,7 @@ export interface ToolResult {
 
 interface AgentState {
   configFile?: string;
+  verifyConfigFile?: string;
   providerFile?: string;
   envVars: Record<string, string>;
   verified: boolean;
@@ -248,6 +249,7 @@ async function executeTool(
         });
 
         state.configFile = generated.filePath;
+        state.verifyConfigFile = generated.verifyPath;
         state.envVars = { ...state.envVars, ...generated.envVars };
 
         result = {
@@ -277,7 +279,7 @@ async function executeTool(
           configFile?: string;
         };
 
-        const configPath = configFile || state.configFile || 'promptfooconfig.yaml';
+        const configPath = configFile || state.verifyConfigFile || 'promptfooconfig.yaml';
         const steps: string[] = [];
 
         // Step 1: Direct provider smoke + session test

--- a/plugins/promptfoo/src/generator/config-outputdir.test.ts
+++ b/plugins/promptfoo/src/generator/config-outputdir.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { generateConfig } from './config.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('generateConfig output paths', () => {
+  it('returns a verify path relative to the output directory', () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crabcode-config-'));
+    tempDirs.push(outputDir);
+
+    const generated = generateConfig({
+      description: 'Test config',
+      providerType: 'http',
+      providerConfig: { url: 'https://example.com', method: 'GET' },
+      outputDir,
+      filename: 'nested-config.yaml',
+    });
+
+    expect(generated.filePath).toBe(path.join(outputDir, 'nested-config.yaml'));
+    expect(generated.verifyPath).toBe('nested-config.yaml');
+    expect(fs.existsSync(generated.filePath)).toBe(true);
+  });
+});

--- a/plugins/promptfoo/src/generator/config.ts
+++ b/plugins/promptfoo/src/generator/config.ts
@@ -21,6 +21,7 @@ export interface GenerateConfigOptions {
 export interface GeneratedConfig {
   yaml: string;
   filePath: string;
+  verifyPath: string;
   envVars: Record<string, string>;
 }
 
@@ -104,6 +105,7 @@ ${Object.entries(envVars).map(([k, v]) => `#   ${k}: ${v}`).join('\n') || '#   (
   return {
     yaml: fullYaml,
     filePath,
+    verifyPath: filename,
     envVars,
   };
 }


### PR DESCRIPTION
## Summary
- keep the user-facing generated config path unchanged
- track a separate relative verify path for promptfoo eval inside the output directory
- add a regression test for generated file and verify paths

## Root cause
CodeQL tracked the user-controlled output directory into the generated config path and then into the later promptfoo eval shell command.

## Validation
- npm test -- src/generator/config-outputdir.test.ts
- npm run build