### PR TITLE
[codex] Fix code scanning alert 3 in generated config filename flow

### DIFF
--- a/plugins/promptfoo/src/generator/config-filename.test.ts
+++ b/plugins/promptfoo/src/generator/config-filename.test.ts
@@ -14,21 +14,23 @@ afterEach(() => {
   }
 });
 
-describe('generateConfig output paths', () => {
-  it('returns a verify path relative to the output directory', () => {
+describe('generateConfig filename handling', () => {
+  it('keeps the requested filename while writing a stable verify config alias', () => {
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crabcode-config-'));
     tempDirs.push(outputDir);
 
     const generated = generateConfig({
-      description: 'Test config',
+      description: 'Custom filename config',
       providerType: 'http',
       providerConfig: { url: 'https://example.com', method: 'GET' },
       outputDir,
-      filename: 'nested-config.yaml',
+      filename: 'custom-config.yaml',
     });
 
-    expect(generated.filePath).toBe(path.join(outputDir, 'nested-config.yaml'));
+    expect(generated.filePath).toBe(path.join(outputDir, 'custom-config.yaml'));
     expect(generated.verifyPath).toBe('promptfooconfig.yaml');
-    expect(fs.existsSync(generated.filePath)).toBe(true);
+    expect(fs.readFileSync(generated.filePath, 'utf-8')).toBe(
+      fs.readFileSync(path.join(outputDir, generated.verifyPath), 'utf-8')
+    );
   });
 });

--- a/plugins/promptfoo/src/generator/config.ts
+++ b/plugins/promptfoo/src/generator/config.ts
@@ -25,6 +25,8 @@ export interface GeneratedConfig {
   envVars: Record<string, string>;
 }
 
+const DEFAULT_CONFIG_FILENAME = 'promptfooconfig.yaml';
+
 /**
  * Generate a promptfoo YAML config
  */
@@ -35,7 +37,7 @@ export function generateConfig(options: GenerateConfigOptions): GeneratedConfig 
     providerConfig,
     envVars = {},
     outputDir = '.',
-    filename = 'promptfooconfig.yaml',
+    filename = DEFAULT_CONFIG_FILENAME,
   } = options;
 
   // Validate providerConfig has required fields for http provider
@@ -101,11 +103,16 @@ ${Object.entries(envVars).map(([k, v]) => `#   ${k}: ${v}`).join('\n') || '#   (
   // Write the file
   const filePath = path.join(outputDir, filename);
   fs.writeFileSync(filePath, fullYaml, 'utf-8');
+  const verifyPath = DEFAULT_CONFIG_FILENAME;
+
+  if (verifyPath !== filename) {
+    fs.writeFileSync(path.join(outputDir, verifyPath), fullYaml, 'utf-8');
+  }
 
   return {
     yaml: fullYaml,
     filePath,
-    verifyPath: filename,
+    verifyPath,
     envVars,
   };
 }


### PR DESCRIPTION
## Summary
- keep the requested config filename for the user-facing output
- write a stable promptfooconfig.yaml alias for verification
- add a regression test for custom filenames plus the stable verify alias

## Root cause
After the output-directory flow was separated, CodeQL still tracked the caller-controlled filename into the verify path that eventually reached promptfoo eval.

## Validation
- npm test -- src/generator/config-filename.test.ts src/generator/config-outputdir.test.ts
- npm run build