### PR TITLE
feat: add version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ crab projects          # list all registered projects
 
 Use `crab` (or `crabcode`) for all commands.
 
+Run `crab version` (or `crab --version`) to check the installed version.
+
 ### Workspace Commands (`crab ws`)
 
 ```bash

--- a/src/crabcode
+++ b/src/crabcode
@@ -18,6 +18,7 @@
 #   config scan       Auto-detect .env files and ports
 #   doctor            Diagnose common issues
 #   cheat             Show cheat sheet / help
+#   version           Show the installed crabcode version
 #   ports             Show port usage across workspaces
 #   wip save          Save work in progress
 #   wip ls            List saved WIP states
@@ -8261,6 +8262,7 @@ show_help() {
   echo "  ports             Show port usage"
   echo "  shared            Show shared volume info"
   echo "  cheat             Show cheat sheet"
+  echo "  version           Show the installed crabcode version"
   echo ""
   echo "Config: $CONFIG_FILE"
 }
@@ -12090,7 +12092,7 @@ main() {
       fi
       rm -f "$tmp_file"
       ;;
-    "--version"|"-v")
+    "version"|"--version"|"-v")
       echo '  /)🦀(\'
       echo "crabcode v$VERSION"
       ;;


### PR DESCRIPTION
## Summary
- add `crab version` as a readable alias for the existing version flags
- include the command in CLI help and the README
- open this PR as a small, ready-for-review smoke test of the automatic review flow

## Validation
- `make test-unit` — 39 tests passed
- `bash -n src/crabcode`
- `./src/crabcode version`
- `./src/crabcode --version`
- `git diff --check`
- `make lint` — skipped because ShellCheck is not installed