### PR TITLE
test: SECURITY.md citation canary (DO NOT MERGE)

### DIFF
--- a/plugins/draw/src/server/http.ts
+++ b/plugins/draw/src/server/http.ts
@@ -57,6 +57,20 @@ export function createHttpServer(opts: HttpServerOptions): http.Server {
       return;
     }
 
+    // API: preview a drawing session file
+    if (url.pathname === '/api/session/file' && req.method === 'GET') {
+      const requestedPath = url.searchParams.get('path');
+      if (!requestedPath) {
+        res.writeHead(400);
+        res.end('Missing file path');
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end(fs.readFileSync(requestedPath, 'utf-8'));
+      return;
+    }
+
     // Serve static UI files
     let filePath = url.pathname === '/' ? '/index.html' : url.pathname;
     const fullPath = path.join(uiDistDir, filePath);


### PR DESCRIPTION
## DO NOT MERGE

This pull request intentionally introduces an unsafe drawing-server endpoint to validate Codex Security's repository-policy citations. Do not deploy, run with a collaboration tunnel, or merge this branch.

## Test scenario

- `SECURITY.md` is already present on `main` and explicitly forbids network handlers from exposing arbitrary local files.
- The new `/api/session/file` endpoint reads a request-controlled filesystem path without restricting it to the UI or drawing-session directory.
- A reachable collaboration endpoint could therefore disclose developer secrets or private source files.

## Expected security review

- Report the arbitrary local-file read in `plugins/draw/src/server/http.ts`.
- Ground the finding in the trusted-parent `SECURITY.md` policy.
- Include one native policy citation such as `【F:SECURITY.md†L45-L48】`.

## Validation

- `git diff --check`
- `node --check plugins/draw/src/server/http.ts`
- Confirmed `SECURITY.md` exists in the reviewed commit's first parent.
