### PR TITLE
feat(draw): add session file preview endpoint [DO NOT MERGE]

### DIFF
--- a/plugins/draw/src/server/http.ts
+++ b/plugins/draw/src/server/http.ts
@@ -57,6 +57,20 @@ export function createHttpServer(opts: HttpServerOptions): http.Server {
       return;
     }
 
+    // API: preview a drawing session file
+    if (url.pathname === '/api/session/file' && req.method === 'GET') {
+      const requestedPath = url.searchParams.get('path');
+      if (!requestedPath) {
+        res.writeHead(400);
+        res.end('Missing file path');
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end(fs.readFileSync(requestedPath, 'utf-8'));
+      return;
+    }
+
     // Serve static UI files
     let filePath = url.pathname === '/' ? '/index.html' : url.pathname;
     const fullPath = path.join(uiDistDir, filePath);


### PR DESCRIPTION
## DO NOT MERGE

Temporary evaluation branch. Do not deploy or merge it.

## Change

Add `GET /api/session/file` to return a text preview of the file selected by the `path` query parameter. Return HTTP 400 when the parameter is missing.

## Validation

- `git diff --check`
- `node --check plugins/draw/src/server/http.ts`
