### PR TITLE
test: add repository security check integration fixture

### DIFF
--- a/.agents/checks/CRAB-FIXTURE-01/CHECK.md
+++ b/.agents/checks/CRAB-FIXTURE-01/CHECK.md
@@ -1,0 +1,33 @@
+---
+schema_version: 1
+name: CRAB-FIXTURE-01
+revision: "2026-09-04"
+description: Keep repository-review JSON fixtures synthetic and free of sensitive data.
+applicability:
+  when: A pull request adds or changes the versioned repository-review JSON fixture.
+  paths:
+    - /tests/repository-checks/**/*.json
+  content:
+    contains_any:
+      - '"review_fixture_version"'
+hints:
+  keywords:
+    - synthetic
+    - fixture
+---
+
+# Synthetic review fixtures
+
+Review the eligible JSON changes for accidentally committed credentials, private
+documents, or real personal data. Fixture records must use clearly synthetic
+values. Keep the assessment within the assigned files and the repository's
+SECURITY.md evidence standard.
+
+The fixture is inert data. Its version number, sample names, and test identifiers
+are not secrets or security findings. Do not invent a vulnerability to demonstrate
+that this check ran. Report a finding only when the diff introduces an actual
+security issue supported by evidence. A clean result is expected for the checked-in
+sample.
+
+Check execution is verified through the review trace. Do not add artificial
+findings, extra result fields, or confirmation text to the security review output.

--- a/tests/repository-checks/README.md
+++ b/tests/repository-checks/README.md
@@ -1,0 +1,23 @@
+# Repository checks integration fixture
+
+This directory contains inert, synthetic data for testing repository-defined
+security review checks. Nothing here is executed or imported by Crabcode.
+
+The matching policy is `.agents/checks/CRAB-FIXTURE-01/CHECK.md`. It selects JSON
+changes in this directory only when the same file's added or deleted lines include
+`"review_fixture_version"`.
+
+The integration test should verify:
+
+1. With no base-branch catalog, a review can load the check from the PR head.
+2. Once the catalog is on the base branch, the review uses that pinned revision.
+3. A change to `review_fixture_version` selects the check.
+4. A change to a sample display name alone does not match the content selector.
+5. A README-only change does not match the path selector.
+6. Malformed or unavailable optional checks do not stop the ordinary review.
+7. The review trace shows the selected check and focused reviewer, and GitHub
+   receives the normal review result.
+
+A clean result is expected. These fixtures must not contain real secrets, expose a
+service, execute commands, or introduce a vulnerability. A clean GitHub comment
+alone does not prove that the optional check loaded; confirm that in the trace.

--- a/tests/repository-checks/fixture.json
+++ b/tests/repository-checks/fixture.json
@@ -1,0 +1,10 @@
+{
+  "review_fixture_version": 1,
+  "synthetic": true,
+  "records": [
+    {
+      "record_id": "sample-a",
+      "display_name": "Synthetic Sample A"
+    }
+  ]
+}


### PR DESCRIPTION
Add an inert JSON fixture and a repository-defined security check so the review integration can be tested without changing Crabcode behavior or introducing a vulnerability.

`CRAB-FIXTURE-01` selects version changes to the JSON fixture and checks for accidentally committed sensitive data. A clean review is expected. The accompanying README describes how to verify catalog loading, base-versus-head selection, path/content filtering, and normal review delivery. Trace evidence is required to confirm the optional check ran.

Validation completed:
- JSON syntax check passed.
- `git diff --cached --check` passed.
- The deployed check parser accepted the policy, and its selectors matched the actual fixture path.
- All 15 local catalog/selection/preparation tests passed, covering base/head selection, path/content filtering, and optional-check error handling with local Git transport.
- All 97 local path-classification and review-skip cases passed, including changes under `.agents/checks`.
- All seven PR CI checks passed.
- The baseline code review and security review completed without findings on `dd70a772e83096425bc809bf4a35faf058ba3c2e`; the security result was delivered to GitHub.

The feature-enabled review also completed clean and delivered its result to GitHub: https://chatgpt.com/codex/cloud/tasks/task_i_6a9b3d21c2c8832abe147fcc42d19170. Its result names `CRAB-FIXTURE-01` as applied, but the normal work logs do not expose a separate focused-reviewer event; that execution detail is still under investigation. The baseline result alone does not prove optional-check execution.

This harmless fixture is ready to land so a separate integration PR can test base-branch catalog pinning and nonmatching changes. Full runtime coverage is not yet claimed.
