### PR TITLE
test: exercise repository check base pinning [DO NOT MERGE]

### DIFF
--- a/.agents/checks/CRAB-FIXTURE-01/CHECK.md
+++ b/.agents/checks/CRAB-FIXTURE-01/CHECK.md
@@ -6,7 +6,7 @@ description: Keep repository-review JSON fixtures synthetic and free of sensitiv
 applicability:
   when: A pull request adds or changes the versioned repository-review JSON fixture.
   paths:
-    - /tests/repository-checks/**/*.json
+    - /tests/repository-checks/nonmatching-control/**/*.json
   content:
     contains_any:
       - '"review_fixture_version"'

--- a/tests/repository-checks/fixture.json
+++ b/tests/repository-checks/fixture.json
@@ -1,5 +1,5 @@
 {
-  "review_fixture_version": 1,
+  "review_fixture_version": 2,
   "synthetic": true,
   "records": [
     {


### PR DESCRIPTION
Change the inert fixture version and give the PR head a nonmatching path selector as integration controls. The existing base-branch policy remains unchanged.

This PR is for runtime validation only and must not be merged. After the review finishes, it will also exercise nonmatching fixture edits, then be closed. No Crabcode executable code is changed.

Validation completed:
- `git diff --check` passed.
- All seven CI checks passed.
- Automatic and manual security reviews completed without reported security issues.
- The deployed selector, run locally against this exact commit, selected the base-branch check for the fixture despite the nonmatching head selector.

Manual review: https://chatgpt.com/codex/cloud/tasks/task_i_6a9b403a5160832ab1b589be692ffc47

This control was closed without merging. The operational API log confirms multi-agent review was requested for this commit despite its nonmatching head selector. A separate child-reviewer execution receipt is not exposed by the available review logs, so that detail remains unverified.
