### PR TITLE
test: exercise repository check selector exclusions [DO NOT MERGE]

### DIFF
--- a/.agents/checks/CRAB-FIXTURE-01/CHECK.md
+++ b/.agents/checks/CRAB-FIXTURE-01/CHECK.md
@@ -18,6 +18,8 @@ hints:
 
 # Synthetic review fixtures
 
+<!-- Integration control: documentation-only change; policy behavior is unchanged. -->
+
 Review the eligible JSON changes for accidentally committed credentials, private
 documents, or real personal data. Fixture records must use clearly synthetic
 values. Keep the assessment within the assigned files and the repository's

--- a/tests/repository-checks/README.md
+++ b/tests/repository-checks/README.md
@@ -21,3 +21,6 @@ The integration test should verify:
 A clean result is expected. These fixtures must not contain real secrets, expose a
 service, execute commands, or introduce a vulnerability. A clean GitHub comment
 alone does not prove that the optional check loaded; confirm that in the trace.
+
+Selector control: mentioning `"review_fixture_version"` in this Markdown file
+does not make it an eligible JSON fixture.

--- a/tests/repository-checks/fixture.json
+++ b/tests/repository-checks/fixture.json
@@ -4,7 +4,7 @@
   "records": [
     {
       "record_id": "sample-a",
-      "display_name": "Synthetic Sample A"
+      "display_name": "Synthetic Sample A - selector control"
     }
   ]
 }


### PR DESCRIPTION
Change an inert sample display name and add a documentation-only selector control. The fixture version and policy behavior remain unchanged.

This PR is for runtime validation only and must not be merged. It will be closed after observing the review and CI results. No Crabcode executable code is changed.

Validation completed:
- `git diff --check` passed.
- All seven CI checks passed.
- Automatic and manual security reviews completed without reported security issues.
- The deployed selector, run locally against this exact commit, assigned no checks: the JSON change lacks a changed version marker, and the Markdown control is outside the JSON path selector.

Manual review: https://chatgpt.com/codex/cloud/tasks/task_i_6a9b4065fb20832aa9f6882f5c53a9be

This control was closed without merging. The operational API log shows no multi-agent override for this review, matching the expected selector exclusion.
